### PR TITLE
Update manifest `matches` to only include day view

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -8,7 +8,7 @@ const sharedManifest = {
   content_scripts: [
     {
       js: ["src/entries/contentScript/main.ts"],
-      matches: ["https://*.harvestapp.com/time/*"],
+      matches: ["https://*.harvestapp.com/time/day/*"],
     },
   ],
   icons: {


### PR DESCRIPTION
Currently an error is displayed when changing to the week overview. With this change fertilizer would not show this error anymore.